### PR TITLE
[m] Changed to use Gitlab API v4.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ var _lodashObjectAssign = require('lodash/object/assign');
 
 var _lodashObjectAssign2 = _interopRequireDefault(_lodashObjectAssign);
 
-var tpl = _uriTemplate2['default'].parse('repository/archive.zip{?private_token,ref}');
+var tpl = _uriTemplate2['default'].parse('repository/archive.zip{?private_token,sha}');
 var DEFAULT_OPTIONS = { extract: 'true', mode: '755', strip: 1 };
 
 var GitlabDownload = (function () {
@@ -61,13 +61,14 @@ var GitlabDownload = (function () {
       var downloadOptions = _ref$downloadOptions === undefined ? {} : _ref$downloadOptions;
 
       var options = (0, _lodashObjectAssign2['default'])({}, DEFAULT_OPTIONS, downloadOptions);
+      remote = encodeURIComponent(remote);
 
       return new Promise(function (resolve, reject) {
         (0, _assert2['default'])(!(0, _underscoreStringIsBlank2['default'])(remote), 'remote is mandatory');
         (0, _assert2['default'])(!(0, _underscoreStringIsBlank2['default'])(ref), 'ref is mandatory');
         (0, _assert2['default'])(!(0, _underscoreStringIsBlank2['default'])(dest), 'dest is mandatory');
 
-        var url = _this.gitlabUrl + '/' + remote + '/' + tpl.expand({ private_token: _this.token, ref: ref });
+        var url = _this.gitlabUrl + '/api/v4/projects/' + remote + '/' + tpl.expand({ private_token: _this.token, sha: ref });
         new _download2['default'](options).get((0, _normalizeUrl2['default'])(url)).dest(dest).run(function (err, files) {
           if (err) {
             reject(err);

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import parser from 'uri-template';
 import normalizeurl from 'normalize-url';
 import assign from 'lodash/object/assign';
 
-var tpl = parser.parse('repository/archive.zip{?private_token,ref}')
+var tpl = parser.parse('repository/archive.zip{?private_token,sha}')
 const DEFAULT_OPTIONS = {extract: 'true', mode: '755', strip: 1};
 
 export default class GitlabDownload {
@@ -18,13 +18,14 @@ export default class GitlabDownload {
 
   download({remote, dest= './', ref = 'master', downloadOptions = {}}) {
     let options = assign({}, DEFAULT_OPTIONS, downloadOptions);
+    remote = encodeURIComponent(remote);
 
     return new Promise((resolve, reject) => {
       assert(!isBlank(remote), `remote is mandatory`);
       assert(!isBlank(ref), `ref is mandatory`);
       assert(!isBlank(dest), `dest is mandatory`);  
       
-      let url = `${this.gitlabUrl}/${remote}/` + tpl.expand({private_token: this.token, ref});
+      let url = `${this.gitlabUrl}/api/v4/projects/${remote}/` + tpl.expand({private_token: this.token, sha: ref});
       new Download(options)
       .get(normalizeurl(url))
       .dest(dest)


### PR DESCRIPTION
 Older URL doesn't work in newer versions.

See - https://gitlab.com/gitlab-com/support-forum/issues/4154